### PR TITLE
Fix for triple backtick nicknames breaking ranking display

### DIFF
--- a/methods/command/ranking/me.js
+++ b/methods/command/ranking/me.js
@@ -108,7 +108,7 @@ function displayRanking(con,msg,sql,title,subText){
 					name = "User Left Discord";
 				else
 					name = ""+user.username;
-				name = name.replace("discord.gg","discord,gg");
+				name = name.replace("discord.gg","discord,gg").replace(/(```)/g, "`\u200b``");
 				embed += "#"+rank+"\t"+name+"\n"+subText(ele)+"\n";
 				rank++;
 			}else if(rank==0)
@@ -121,7 +121,7 @@ function displayRanking(con,msg,sql,title,subText){
 			uname = uname.username;
 		else 
 			uname = "you";
-		uname = uname.replace("discord.gg","discord,gg");
+		uname = uname.replace("discord.gg","discord,gg").replace(/(```)/g, "`\u200b``");
 		embed += "< "+rank+"   "+uname+" >\n"+subText(me)+"\n";
 		rank++;
 

--- a/methods/command/ranking/top.js
+++ b/methods/command/ranking/top.js
@@ -103,7 +103,7 @@ function displayRanking(con,msg,count,globalRank,sql,title,subText){
 				var user = msg.guild.members.get(id);
 				var name = "";
 				if(user&&user.nickname) 
-					name = user.nickname+" ("+user.user.username+")";
+					name = user.nickname.replace(/(```)/g, "`\u200b``")+" ("+user.user.username+")";
 				else if(user&&user.user.username)
 					name = ""+user.user.username;
 				else

--- a/methods/command/ranking/top.js
+++ b/methods/command/ranking/top.js
@@ -103,7 +103,7 @@ function displayRanking(con,msg,count,globalRank,sql,title,subText){
 				var user = msg.guild.members.get(id);
 				var name = "";
 				if(user&&user.nickname) 
-					name = user.nickname.replace(/(```)/g, "`\u200b``")+" ("+user.user.username+")";
+					name = user.nickname+" ("+user.user.username+")";
 				else if(user&&user.user.username)
 					name = ""+user.user.username;
 				else
@@ -117,7 +117,7 @@ function displayRanking(con,msg,count,globalRank,sql,title,subText){
 					name = ""+user.username;
 			}
 
-			name = name.replace("discord.gg","discord,gg");
+			name = name.replace("discord.gg","discord,gg").replace(/(```)/g, "`\u200b``");
 			embed += "#"+rank+"\t"+name+subText(ele,rank);
 			rank++;
 		};


### PR DESCRIPTION
There doesn't really seem to be an 'official' way to escape a triple backtick within a code-block, but adding zero-width spaces should work well enough.