### PR TITLE
Fixed offensive pet name censor not working correctly

### DIFF
--- a/methods/command/battle/acceptbattle.js
+++ b/methods/command/battle/acceptbattle.js
@@ -76,15 +76,19 @@ function startBattle(con,msg,user1,pid1,user2,pid2,amount,send,p){
 		"FROM (cowoncy NATURAL JOIN animal) LEFT JOIN (animal_food NATURAL JOIN food) "+
 		"ON animal.pid = animal_food.pid "+
 		"WHERE id = "+user2.id+" AND animal.pid = "+pid2+" GROUP BY animal.pid;";
+	sql += "SELECT young FROM guild WHERE id = "+msg.guild.id+";";
 	sql += "UPDATE cowoncy SET money = money - "+amount+" WHERE id IN ("+user1.id+","+user2.id+");"
 	con.query(sql,function(err,rows,fields){
 		p.logger.value('cowoncy',(amount*-1),['command:battleuser','id:'+user1.id]);
 		p.logger.value('cowoncy',(amount*-1),['command:battleuser','id:'+user2.id]);
 		if(err) throw err;
 
+		//Check if guild is kid friendly
+		var censor = (rows[2][0]!=undefined && rows[2][0].young)
+
 		//Grab pet info
-		var upet = battleUtil.extractInfo(rows[0][0],user1);
-		var opet = battleUtil.extractInfo(rows[1][0],user2);
+		var upet = battleUtil.extractInfo(rows[0][0],user1,censor);
+		var opet = battleUtil.extractInfo(rows[1][0],user2,censor);
 
 		//Check if pets are valid
 		if(upet == undefined){

--- a/methods/command/battle/battle.js
+++ b/methods/command/battle/battle.js
@@ -39,14 +39,14 @@ module.exports = new CommandInterface({
 })
 
 function fight(con,msg,send,p,count){
-	var sql = "SELECT id,money,nickname,name,lvl,att,hp,lvl,streak,xp, "+
+	var sql = "SELECT id,money,nickname,name,lvl,att,hp,lvl,streak,xp,offensive, "+
 			"GROUP_CONCAT((CASE WHEN pfid = 1 THEN fname ELSE NULL END)) AS one, "+
 			"GROUP_CONCAT((CASE WHEN pfid = 2 THEN fname ELSE NULL END)) AS two, "+
 			"GROUP_CONCAT((CASE WHEN pfid = 3 THEN fname ELSE NULL END)) AS three "+
 		"FROM (cowoncy NATURAL JOIN animal) LEFT JOIN (animal_food NATURAL JOIN food) "+
 		"ON animal.pid = animal_food.pid "+
 		"WHERE id = "+msg.author.id+" AND pet = name GROUP BY animal.pid;";
-	sql += "SELECT id,nickname,name,lvl,att,hp,lvl,streak,xp, "+
+	sql += "SELECT id,nickname,name,lvl,att,hp,lvl,streak,xp,offensive, "+
 			"GROUP_CONCAT((CASE WHEN pfid = 1 THEN fname ELSE NULL END)) AS one, "+
 			"GROUP_CONCAT((CASE WHEN pfid = 2 THEN fname ELSE NULL END)) AS two, "+
 			"GROUP_CONCAT((CASE WHEN pfid = 3 THEN fname ELSE NULL END)) AS three "+
@@ -66,6 +66,7 @@ function fight(con,msg,send,p,count){
 		var censor = (rows[2][0]!=undefined && rows[2][0].young)
 
 		//Grab pet info
+		console.log(rows[0][0])
 		var upet = battleUtil.extractInfo(rows[0][0],msg.author,censor);
 		var opet = battleUtil.extractInfo(rows[1][0],{id:rows[1][0].id},censor);//await global.getUser((rows[1][0])?rows[1][0].id:undefined,false),censor);
 


### PR DESCRIPTION
The `offensive` column wasn't being requested from the `animals` table, so badwords were never being censored regardless of the guild's `young` status.