### PR TITLE
[Bugfix] Discharge fires for the wrong pet

### DIFF
--- a/methods/command/battle/passives/discharge.js
+++ b/methods/command/battle/passives/discharge.js
@@ -20,7 +20,7 @@ module.exports = class Discharge extends PassiveInterface{
 		this.qualityList = [[100,140]];
 	}
 
-	postReplenish(animal,from,amount,tags){
+	postReplenished(animal,from,amount,tags){
 		/* Ignore if tags.thorns flag is true */
 		if(tags.discharge) return;
 		let totalDamage = amount.reduce((a,b)=>a+b,0)*this.stats[0]/100;


### PR DESCRIPTION
Currently only works if the pet wielding the discharge weapon gives someone else WP, meaning it only works on a scepter or wand which is not the intended behaviour per discussion.