### PR TITLE
Adding support for an inactive team

### DIFF
--- a/secret/CREATE-OWO-TABLES.sql
+++ b/secret/CREATE-OWO-TABLES.sql
@@ -546,6 +546,7 @@ CREATE TABLE `pet_team` (
   `censor` tinyint(1) DEFAULT '0',
   `streak` int(10) unsigned DEFAULT '0',
   `highest_streak` int(10) unsigned DEFAULT '0',
+  `active` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`pgid`,`uid`),
   KEY `uid` (`uid`),
   CONSTRAINT `pet_team_ibfk_1` FOREIGN KEY (`uid`) REFERENCES `user` (`uid`)

--- a/src/commands/commandList/battle/ab.js
+++ b/src/commands/commandList/battle/ab.js
@@ -165,7 +165,7 @@ module.exports = new CommandInterface({
 async function parseTeams(p, user, sender,flags){
 	let sql = `SELECT pet_team.pgid,tname,pos,animal.name,animal.nickname,animal.pid,animal.xp,user_weapon.uwid,user_weapon.wid,user_weapon.stat,user_weapon_passive.pcount,user_weapon_passive.wpid,user_weapon_passive.stat as pstat
 		FROM user
-			INNER JOIN pet_team ON user.uid = pet_team.uid
+			INNER JOIN pet_team ON user.uid = pet_team.uid AND pet_team.active = 1
 			INNER JOIN pet_team_animal ON pet_team.pgid = pet_team_animal.pgid
 			INNER JOIN animal ON pet_team_animal.pid = animal.pid
 			LEFT JOIN user_weapon ON user_weapon.pid = pet_team_animal.pid
@@ -174,7 +174,7 @@ async function parseTeams(p, user, sender,flags){
 		ORDER BY pos ASC;`;
 	sql += `SELECT pet_team.pgid,tname,pos,animal.name,animal.nickname,animal.pid,animal.xp,user_weapon.uwid,user_weapon.wid,user_weapon.stat,user_weapon_passive.pcount,user_weapon_passive.wpid,user_weapon_passive.stat as pstat
 		FROM user
-			INNER JOIN pet_team ON user.uid = pet_team.uid
+			INNER JOIN pet_team ON user.uid = pet_team.uid AND pet_team.active = 1
 			INNER JOIN pet_team_animal ON pet_team.pgid = pet_team_animal.pgid
 			INNER JOIN animal ON pet_team_animal.pid = animal.pid
 			LEFT JOIN user_weapon ON user_weapon.pid = pet_team_animal.pid

--- a/src/commands/commandList/battle/team.js
+++ b/src/commands/commandList/battle/team.js
@@ -16,11 +16,11 @@ module.exports = new CommandInterface({
 
 	alias:["team","squad"],
 
-	args:"{add|remove|rename}",
+	args:"{add|remove|rename|swapactive}",
 
 	desc:"Display your team! ",
 
-	example:["owo team","owo team add dog 1","owo team rename My Team"],
+	example:["owo team","owo team add dog 1","owo team rename My Team","owo team swapactive"],
 
 	related:["owo battle"],
 
@@ -61,8 +61,12 @@ module.exports = new CommandInterface({
 				await remove(p);
 
 		/* Rename the team */
-		}else if(subcommand=="rename"||subcommand=="r"||subcommand=="name")
+		}else if(subcommand=="rename"||subcommand=="r"||subcommand=="name"){
 			await rename(p);
+		}
+		else if(subcommand=="swapactive") {
+			await swapActive(p);
+		}
 
 		/* If they need help
 		else if(subcommand=="help"){
@@ -175,4 +179,16 @@ async function rename(p){
 		p.errorMsg(`, something went wrong... Try again!`,5000);
 	}
 
+}
+
+/*
+ * swap active team
+ */
+async function swapActive(p) {
+	try{
+		await teamUtil.swapActive(p);
+	}catch(err){
+		console.error(err);
+		p.errorMsg(`, something went wrong... Try again!`,5000);
+	}
 }

--- a/src/commands/commandList/battle/util/battleFriendUtil.js
+++ b/src/commands/commandList/battle/util/battleFriendUtil.js
@@ -26,7 +26,7 @@ exports.challenge = async function(p,id,bet){
 	/* Query two teams */
 	let sql = `SELECT pet_team.pgid,tname,pos,animal.name,animal.nickname,animal.pid,animal.xp,user_weapon.uwid,user_weapon.wid,user_weapon.stat,user_weapon_passive.pcount,user_weapon_passive.wpid,user_weapon_passive.stat as pstat
 		FROM user
-			INNER JOIN pet_team ON user.uid = pet_team.uid
+			INNER JOIN pet_team ON user.uid = pet_team.uid AND pet_team.active = 1
 			INNER JOIN pet_team_animal ON pet_team.pgid = pet_team_animal.pgid
 			INNER JOIN animal ON pet_team_animal.pid = animal.pid
 			LEFT JOIN user_weapon ON user_weapon.pid = pet_team_animal.pid
@@ -35,7 +35,7 @@ exports.challenge = async function(p,id,bet){
 		ORDER BY pos ASC;`;
 	sql += `SELECT pet_team.pgid,tname,pos,animal.name,animal.nickname,animal.pid,animal.xp,user_weapon.uwid,user_weapon.wid,user_weapon.stat,user_weapon_passive.pcount,user_weapon_passive.wpid,user_weapon_passive.stat as pstat
 		FROM user
-			INNER JOIN pet_team ON user.uid = pet_team.uid
+			INNER JOIN pet_team ON user.uid = pet_team.uid AND pet_team.active = 1
 			INNER JOIN pet_team_animal ON pet_team.pgid = pet_team_animal.pgid
 			INNER JOIN animal ON pet_team_animal.pid = animal.pid
 			LEFT JOIN user_weapon ON user_weapon.pid = pet_team_animal.pid

--- a/src/commands/commandList/battle/util/battleUtil.js
+++ b/src/commands/commandList/battle/util/battleUtil.js
@@ -32,19 +32,18 @@ var getBattle = exports.getBattle = async function(p,setting){
 	/* And our team */
 	let sql = `SELECT pet_team_battle.pgid,tname,pos,animal.name,animal.nickname,animal.pid,animal.xp,user_weapon.uwid,user_weapon.wid,user_weapon.stat,user_weapon_passive.pcount,user_weapon_passive.wpid,user_weapon_passive.stat as pstat,cphp,cpwp,cehp,cewp,pet_team.streak,pet_team.highest_streak
 		FROM user
-			INNER JOIN pet_team ON user.uid = pet_team.uid
+			INNER JOIN pet_team ON user.uid = pet_team.uid AND pet_team.active = 1
 			INNER JOIN pet_team_battle ON pet_team.pgid = pet_team_battle.pgid
 			INNER JOIN pet_team_animal ON pet_team_battle.pgid = pet_team_animal.pgid
 			INNER JOIN animal ON pet_team_animal.pid = animal.pid
 			LEFT JOIN user_weapon ON user_weapon.pid = pet_team_animal.pid
 			LEFT JOIN user_weapon_passive ON user_weapon.uwid = user_weapon_passive.uwid
 		WHERE user.id = ${p.msg.author.id}
-			AND pet_team_battle.active = 1
 		ORDER BY pos ASC;`;
 	/* Query enemy team */
 	sql += `SELECT pet_team.censor as ptcensor,animal.offensive as acensor,pet_team_battle.epgid,enemyTeam.tname,pos,animal.name,animal.nickname,animal.pid,animal.xp,user_weapon.uwid,user_weapon.wid,user_weapon.stat,user_weapon_passive.pcount,user_weapon_passive.wpid,user_weapon_passive.stat as pstat,cphp,cpwp,cehp,cewp
 		FROM user
-			INNER JOIN pet_team ON user.uid = pet_team.uid
+			INNER JOIN pet_team ON user.uid = pet_team.uid AND pet_team.active = 1
 			INNER JOIN pet_team_battle ON pet_team.pgid = pet_team_battle.pgid
 			INNER JOIN pet_team_animal ON pet_team_battle.epgid = pet_team_animal.pgid
 			INNER JOIN pet_team enemyTeam ON pet_team_battle.epgid = enemyTeam.pgid
@@ -52,11 +51,10 @@ var getBattle = exports.getBattle = async function(p,setting){
 			LEFT JOIN user_weapon ON user_weapon.pid = pet_team_animal.pid
 			LEFT JOIN user_weapon_passive ON user_weapon.uwid = user_weapon_passive.uwid
 		WHERE user.id = ${p.msg.author.id}
-			AND pet_team_battle.active = 1
 		ORDER BY pos ASC;`;
 	sql += `SELECT pet_team_battle_buff.*
 		FROM user
-			INNER JOIN pet_team ON user.uid = pet_team.uid
+			INNER JOIN pet_team ON user.uid = pet_team.uid AND pet_team.active = 1
 			INNER JOIN pet_team_battle_buff ON pet_team.pgid = pet_team_battle_buff.pgid
 		WHERE user.id = ${p.msg.author.id};`
 

--- a/src/commands/commandList/battle/util/teamUtil.js
+++ b/src/commands/commandList/battle/util/teamUtil.js
@@ -102,7 +102,7 @@ exports.addMember = async function(p,animal,pos){
  * remove = must be either 1-3 or an animal
  */
 exports.removeMember = async function(p,remove){
-	let sql = `SELECT pos,animal.pid,name FROM user LEFT JOIN pet_team ON user.uid = pet_team.uid LEFT JOIN (pet_team_animal NATURAL JOIN animal) ON pet_team.pgid = pet_team_animal.pgid WHERE user.id = ${p.msg.author.id} AND pet_team.active = 1 ORDER BY pos ASC;`;
+	let sql = `SELECT pos,animal.pid,name FROM user LEFT JOIN pet_team ON user.uid = pet_team.uid AND pet_team.active = 1 LEFT JOIN (pet_team_animal NATURAL JOIN animal) ON pet_team.pgid = pet_team_animal.pgid WHERE user.id = ${p.msg.author.id} ORDER BY pos ASC;`;
 
 	/* If its a position */
 	if(p.global.isInt(remove)){

--- a/src/commands/commandList/battle/util/weaponUtil.js
+++ b/src/commands/commandList/battle/util/weaponUtil.js
@@ -435,7 +435,7 @@ exports.equip = async function(p,uwid,pet){
 	}
 	/* Construct sql depending in pet parameter */
 	if(p.global.isInt(pet)){
-		var pid = `(SELECT pid FROM user a LEFT JOIN pet_team b ON a.uid = b.uid LEFT JOIN pet_team_animal c ON b.pgid = c.pgid WHERE a.id = ${p.msg.author.id} AND pos = ${pet})`
+		var pid = `(SELECT pid FROM user a LEFT JOIN pet_team b ON a.uid = b.uid AND b.active = 1 LEFT JOIN pet_team_animal c ON b.pgid = c.pgid WHERE a.id = ${p.msg.author.id} AND pos = ${pet})`
 	}else{
 		var pid = `(SELECT pid FROM animal WHERE name = '${pet.value}' AND id = ${p.msg.author.id})`;
 	}

--- a/src/commands/commandList/ranking/me.js
+++ b/src/commands/commandList/ranking/me.js
@@ -423,12 +423,12 @@ function getTeamRanking(globalRank,con,msg,p){
 	if(globalRank){
 		sql = "SELECT * FROM animal WHERE (xp) > (SELECT xp FROM animal NATURAL JOIN cowoncy WHERE id = "+msg.author.id+" AND pet = name) ORDER BY xp ASC LIMIT 2;";
 		sql += "SELECT * FROM animal WHERE (xp)  < (SELECT xp FROM animal NATURAL JOIN cowoncy WHERE id = "+msg.author.id+" AND pet = name) ORDER BY xp DESC LIMIT 2;";
-		sql += "SELECT *,(SELECT COUNT(*)+1 FROM animal WHERE (xp > c.xp)) AS rank FROM animal c NATURAL JOIN cowoncy WHERE c.id = "+msg.author.id+" AND c.name = pet  ORDER BY xp DESC LIMIT 1;";
+		sql += "SELECT *,(SELECT COUNT(*)+1 FROM animal WHERE (xp > c.xp)) AS 'rank' FROM animal c NATURAL JOIN cowoncy WHERE c.id = "+msg.author.id+" AND c.name = pet  ORDER BY xp DESC LIMIT 1;";
 	}else{
 		let users = global.getids(msg.channel.guild.members);
 		sql = "SELECT * FROM animal WHERE id IN ("+users+") AND (lvl,xp) > (SELECT lvl,xp FROM animal NATURAL JOIN cowoncy WHERE id = "+msg.author.id+" AND pet = name) ORDER BY lvl ASC, xp ASC LIMIT 2;";
 		sql += "SELECT * FROM animal WHERE id IN ("+users+") AND (lvl,xp) < (SELECT lvl,xp FROM animal NATURAL JOIN cowoncy WHERE id = "+msg.author.id+" AND pet = name) ORDER BY lvl DESC, xp DESC LIMIT 2;";
-		sql += "SELECT *,(SELECT COUNT(*)+1 FROM animal WHERE id IN ("+users+") AND ((lvl > c.lvl) OR (lvl = c.lvl AND xp > c.xp))) AS rank FROM animal c NATURAL JOIN cowoncy WHERE c.id = "+msg.author.id+" AND c.name = pet ORDER BY lvl DESC, xp DESC LIMIT 1;";
+		sql += "SELECT *,(SELECT COUNT(*)+1 FROM animal WHERE id IN ("+users+") AND ((lvl > c.lvl) OR (lvl = c.lvl AND xp > c.xp))) AS 'rank' FROM animal c NATURAL JOIN cowoncy WHERE c.id = "+msg.author.id+" AND c.name = pet ORDER BY lvl DESC, xp DESC LIMIT 1;";
 	}
 
 	displayRanking(con,msg,sql,
@@ -445,14 +445,14 @@ function getTeamRanking(globalRank,con,msg,p){
 function getBattleRanking(globalRank,con,msg,p){
 	let sql;
 	if(globalRank){
-		sql = "SELECT u1.tname,u1.id,u1.streak FROM pet_team AS u INNER JOIN user ON u.uid = user.uid LEFT JOIN ( SELECT tname,id,streak FROM pet_team INNER JOIN user ON pet_team.uid = user.uid ORDER BY streak ASC ) AS u1 ON u1.streak > u.streak WHERE user.id = "+msg.author.id+" ORDER BY u1.streak ASC LIMIT 2;";
-		sql += "SELECT u1.tname,u1.id,u1.streak FROM pet_team AS u INNER JOIN user ON u.uid = user.uid LEFT JOIN ( SELECT tname,id,streak FROM pet_team INNER JOIN user ON pet_team.uid = user.uid ORDER BY streak DESC ) AS u1 ON u1.streak < u.streak WHERE user.id = "+msg.author.id+" ORDER BY u1.streak DESC LIMIT 2;";
-		sql +=  "SELECT c.tname,user.id,c.streak, (SELECT COUNT(*)+1 FROM pet_team WHERE streak > c.streak) AS rank FROM pet_team c INNER JOIN user ON c.uid = user.uid WHERE user.id = "+msg.author.id+";";
+		sql = "SELECT u1.tname,u1.id,u1.streak FROM pet_team AS u INNER JOIN user ON u.uid = user.uid LEFT JOIN ( SELECT tname,id,streak FROM pet_team INNER JOIN user ON pet_team.uid = user.uid ORDER BY streak ASC ) AS u1 ON u1.streak > u.streak WHERE user.id = "+msg.author.id+" AND u.active = 1 ORDER BY u1.streak ASC LIMIT 2;";
+		sql += "SELECT u1.tname,u1.id,u1.streak FROM pet_team AS u INNER JOIN user ON u.uid = user.uid LEFT JOIN ( SELECT tname,id,streak FROM pet_team INNER JOIN user ON pet_team.uid = user.uid ORDER BY streak DESC ) AS u1 ON u1.streak < u.streak WHERE user.id = "+msg.author.id+" AND u.active = 1 ORDER BY u1.streak DESC LIMIT 2;";
+		sql +=  "SELECT c.tname,user.id,c.streak, (SELECT COUNT(*)+1 FROM pet_team WHERE streak > c.streak) AS 'rank' FROM pet_team c INNER JOIN user ON c.uid = user.uid WHERE user.id = "+msg.author.id+" AND c.active = 1;";
 	}else{
 		let users = global.getids(msg.channel.guild.members);
-		sql = "SELECT u1.tname,u1.id,u1.streak FROM pet_team AS u INNER JOIN user ON u.uid = user.uid LEFT JOIN ( SELECT tname,id,streak FROM pet_team INNER JOIN user ON pet_team.uid = user.uid WHERE id IN ("+users+") ORDER BY streak ASC ) AS u1 ON u1.streak > u.streak WHERE user.id = "+msg.author.id+" ORDER BY u1.streak ASC LIMIT 2;";
-		sql += "SELECT u1.tname,u1.id,u1.streak FROM pet_team AS u INNER JOIN user ON u.uid = user.uid LEFT JOIN ( SELECT tname,id,streak FROM pet_team INNER JOIN user ON pet_team.uid = user.uid WHERE id IN ("+users+") ORDER BY streak DESC ) AS u1 ON u1.streak < u.streak WHERE user.id = "+msg.author.id+" ORDER BY u1.streak DESC LIMIT 2;";
-		sql +=  "SELECT c.tname,user.id,c.streak, (SELECT COUNT(*)+1 FROM pet_team LEFT JOIN user ON pet_team.uid = user.uid WHERE id IN ("+users+") AND streak > c.streak) AS rank FROM pet_team c INNER JOIN user ON c.uid = user.uid WHERE user.id = "+msg.author.id+";";
+		sql = "SELECT u1.tname,u1.id,u1.streak FROM pet_team AS u INNER JOIN user ON u.uid = user.uid LEFT JOIN ( SELECT tname,id,streak FROM pet_team INNER JOIN user ON pet_team.uid = user.uid WHERE id IN ("+users+") ORDER BY streak ASC ) AS u1 ON u1.streak > u.streak WHERE user.id = "+msg.author.id+" AND u.active = 1 ORDER BY u1.streak ASC LIMIT 2;";
+		sql += "SELECT u1.tname,u1.id,u1.streak FROM pet_team AS u INNER JOIN user ON u.uid = user.uid LEFT JOIN ( SELECT tname,id,streak FROM pet_team INNER JOIN user ON pet_team.uid = user.uid WHERE id IN ("+users+") ORDER BY streak DESC ) AS u1 ON u1.streak < u.streak WHERE user.id = "+msg.author.id+" AND u.active = 1 ORDER BY u1.streak DESC LIMIT 2;";
+		sql +=  "SELECT c.tname,user.id,c.streak, (SELECT COUNT(*)+1 FROM pet_team LEFT JOIN user ON pet_team.uid = user.uid WHERE id IN ("+users+") AND streak > c.streak) AS 'rank' FROM pet_team c INNER JOIN user ON c.uid = user.uid WHERE user.id = "+msg.author.id+" AND c.active = 1;";
 	}
 
 	displayRanking(con,msg,sql,

--- a/src/commands/commandList/ranking/top.js
+++ b/src/commands/commandList/ranking/top.js
@@ -236,11 +236,11 @@ function getPetRanking(globalRank, con, msg, count,p){
 	let sql;
 	if(globalRank){
 		sql = "SELECT * FROM animal ORDER BY xp DESC LIMIT "+count+";";
-		sql +=  "SELECT *,(SELECT COUNT(*)+1 FROM animal WHERE xp > c.xp) AS rank FROM animal c WHERE c.id = "+msg.author.id+" ORDER BY xp DESC LIMIT 1;";
+		sql +=  "SELECT *,(SELECT COUNT(*)+1 FROM animal WHERE xp > c.xp) AS 'rank' FROM animal c WHERE c.id = "+msg.author.id+" ORDER BY xp DESC LIMIT 1;";
 	}else{
 		let users = global.getids(msg.channel.guild.members);
 		sql = "SELECT * FROM animal WHERE id IN ("+users+") ORDER BY xp DESC LIMIT "+count+";";
-		sql +=  "SELECT *,(SELECT COUNT(*)+1 FROM animal WHERE id IN ("+users+") AND xp > c.xp) AS rank FROM animal c WHERE c.id = "+msg.author.id+" ORDER BY xp DESC LIMIT 1;";
+		sql +=  "SELECT *,(SELECT COUNT(*)+1 FROM animal WHERE id IN ("+users+") AND xp > c.xp) AS 'rank' FROM animal c WHERE c.id = "+msg.author.id+" ORDER BY xp DESC LIMIT 1;";
 	}
 
 	displayRanking(con,msg,count,globalRank,sql,
@@ -370,11 +370,11 @@ function getGuildRanking(con, msg, count,p){
 function getBattleRanking(globalRank, con, msg, count,p){
 	let sql;
 	if(globalRank){
-		sql = "SELECT * FROM pet_team INNER JOIN user ON user.uid = pet_team.uid ORDER BY streak DESC LIMIT "+count+";";
-		sql +=  "SELECT *, (SELECT COUNT(*)+1 FROM pet_team WHERE streak > c.streak) AS rank FROM pet_team c INNER JOIN user ON c.uid = user.uid WHERE user.id = "+msg.author.id+";";
+		sql = "SELECT * FROM pet_team INNER JOIN user ON user.uid = pet_team.uid WHERE pet_team.active = 1 ORDER BY streak DESC LIMIT "+count+";";
+		sql +=  "SELECT *, (SELECT COUNT(*)+1 FROM pet_team WHERE streak > c.streak) AS 'rank' FROM pet_team c INNER JOIN user ON c.uid = user.uid WHERE user.id = "+msg.author.id+";";
 	}else{
 		let users = global.getids(msg.channel.guild.members);
-		sql = "SELECT * FROM pet_team INNER JOIN user ON pet_team.uid = user.uid WHERE id IN ("+users+") ORDER BY streak DESC LIMIT "+count+";";
+		sql = "SELECT * FROM pet_team INNER JOIN user ON pet_team.uid = user.uid WHERE id IN ("+users+") and pet_team.active = 1 ORDER BY streak DESC LIMIT "+count+";";
 		sql +=  "SELECT *, (SELECT COUNT(*)+1 FROM pet_team LEFT JOIN user ON pet_team.uid = user.uid WHERE id IN ("+users+") AND streak > c.streak) AS rank FROM pet_team c INNER JOIN user ON c.uid = user.uid WHERE user.id = "+msg.author.id+";";
 	}
 

--- a/src/commands/commandList/ranking/top.js
+++ b/src/commands/commandList/ranking/top.js
@@ -371,11 +371,11 @@ function getBattleRanking(globalRank, con, msg, count,p){
 	let sql;
 	if(globalRank){
 		sql = "SELECT * FROM pet_team INNER JOIN user ON user.uid = pet_team.uid WHERE pet_team.active = 1 ORDER BY streak DESC LIMIT "+count+";";
-		sql +=  "SELECT *, (SELECT COUNT(*)+1 FROM pet_team WHERE streak > c.streak) AS 'rank' FROM pet_team c INNER JOIN user ON c.uid = user.uid WHERE user.id = "+msg.author.id+";";
+		sql +=  "SELECT *, (SELECT COUNT(*)+1 FROM pet_team WHERE streak > c.streak) AS 'rank' FROM pet_team c INNER JOIN user ON c.uid = user.uid WHERE user.id = "+msg.author.id+" AND c.active = 1;";
 	}else{
 		let users = global.getids(msg.channel.guild.members);
 		sql = "SELECT * FROM pet_team INNER JOIN user ON pet_team.uid = user.uid WHERE id IN ("+users+") and pet_team.active = 1 ORDER BY streak DESC LIMIT "+count+";";
-		sql +=  "SELECT *, (SELECT COUNT(*)+1 FROM pet_team LEFT JOIN user ON pet_team.uid = user.uid WHERE id IN ("+users+") AND streak > c.streak) AS rank FROM pet_team c INNER JOIN user ON c.uid = user.uid WHERE user.id = "+msg.author.id+";";
+		sql +=  "SELECT *, (SELECT COUNT(*)+1 FROM pet_team LEFT JOIN user ON pet_team.uid = user.uid WHERE id IN ("+users+") AND streak > c.streak) AS rank FROM pet_team c INNER JOIN user ON c.uid = user.uid WHERE user.id = "+msg.author.id+" AND c.active = 1;";
 	}
 
 	displayRanking(con,msg,count,globalRank,sql,

--- a/src/commands/commandList/social/util/profileUtil.js
+++ b/src/commands/commandList/social/util/profileUtil.js
@@ -152,10 +152,10 @@ function shortenInt(value){
 
 async function getTeam(p,user){
 	let sql = `SELECT tname,name,xp
-		FROM user INNER JOIN pet_team ON user.uid = pet_team.uid 
+		FROM user INNER JOIN pet_team ON user.uid = pet_team.uid AND pet_team.active = 1 
 			INNER JOIN pet_team_animal ON pet_team.pgid = pet_team_animal.pgid 
 			INNER JOIN animal ON pet_team_animal.pid = animal.pid 
-		WHERE user.id = ${user.id}
+		WHERE user.id = ${user.id} 
 		ORDER BY pos DESC`;
 	let result = await p.query(sql);
 	if(!result||!result[0]) return;

--- a/src/commands/commandList/zoo/autohunt.js
+++ b/src/commands/commandList/zoo/autohunt.js
@@ -74,7 +74,7 @@ async function claim(p,msg,con,query,bot){
 	sql = "";
 	//Get total exp
 	let totalExp = Math.floor(autohuntutil.getLvl(query.exp,0,"exp").stat*duration);
-	sql += `UPDATE IGNORE user INNER JOIN pet_team ON user.uid = pet_team.uid and pet_team.active = 1 INNER JOIN pet_team_animal ON pet_team.pgid = pet_team_animal.pgid INNER JOIN animal ON pet_team_animal.pid = animal.pid set animal.xp = animal.xp + ${totalExp} WHERE  user.id = ${msg.author.id};`;
+	sql += `UPDATE IGNORE user INNER JOIN pet_team ON user.uid = pet_team.uid AND pet_team.active = 1 INNER JOIN pet_team_animal ON pet_team.pgid = pet_team_animal.pgid INNER JOIN animal ON pet_team_animal.pid = animal.pid set animal.xp = animal.xp + ${totalExp} WHERE  user.id = ${msg.author.id};`;
 
 	//Get all animal
 	let total = {};

--- a/src/commands/commandList/zoo/autohunt.js
+++ b/src/commands/commandList/zoo/autohunt.js
@@ -74,7 +74,7 @@ async function claim(p,msg,con,query,bot){
 	sql = "";
 	//Get total exp
 	let totalExp = Math.floor(autohuntutil.getLvl(query.exp,0,"exp").stat*duration);
-	sql += `UPDATE IGNORE user INNER JOIN pet_team ON user.uid = pet_team.uid INNER JOIN pet_team_animal ON pet_team.pgid = pet_team_animal.pgid INNER JOIN animal ON pet_team_animal.pid = animal.pid set animal.xp = animal.xp + ${totalExp} WHERE  user.id = ${msg.author.id};`;
+	sql += `UPDATE IGNORE user INNER JOIN pet_team ON user.uid = pet_team.uid and pet_team.active = 1 INNER JOIN pet_team_animal ON pet_team.pgid = pet_team_animal.pgid INNER JOIN animal ON pet_team_animal.pid = animal.pid set animal.xp = animal.xp + ${totalExp} WHERE  user.id = ${msg.author.id};`;
 
 	//Get all animal
 	let total = {};

--- a/src/commands/commandList/zoo/catch.js
+++ b/src/commands/commandList/zoo/catch.js
@@ -38,7 +38,7 @@ module.exports = new CommandInterface({
 		let msg=p.msg,con=p.con;
 
 		let sql = "SELECT money,IF(patreonAnimal = 1 OR (TIMESTAMPDIFF(MONTH,patreonTimer,NOW())<patreonMonths),1,0) as patreon FROM cowoncy LEFT JOIN user ON cowoncy.id = user.id LEFT JOIN patreons ON user.uid = patreons.uid WHERE cowoncy.id = "+msg.author.id+";";
-		sql += `SELECT name,nickname,animal.pid FROM user INNER JOIN pet_team ON user.uid = pet_team.uid and pet_team.active = 1 INNER JOIN pet_team_animal ON pet_team.pgid = pet_team_animal.pgid INNER JOIN animal ON pet_team_animal.pid = animal.pid
+		sql += `SELECT name,nickname,animal.pid FROM user INNER JOIN pet_team ON user.uid = pet_team.uid AND pet_team.active = 1 INNER JOIN pet_team_animal ON pet_team.pgid = pet_team_animal.pgid INNER JOIN animal ON pet_team_animal.pid = animal.pid
 				WHERE user.id = ${p.msg.author.id};`;
 		sql += "SELECT *,TIMESTAMPDIFF(HOUR,claim,NOW()) as time FROM lootbox WHERE id = "+msg.author.id+";";
 		sql += "SELECT uid,activecount,gname,type FROM user NATURAL JOIN user_gem NATURAL JOIN gem WHERE id = "+msg.author.id+" AND activecount > 0;";

--- a/src/commands/commandList/zoo/catch.js
+++ b/src/commands/commandList/zoo/catch.js
@@ -38,7 +38,7 @@ module.exports = new CommandInterface({
 		let msg=p.msg,con=p.con;
 
 		let sql = "SELECT money,IF(patreonAnimal = 1 OR (TIMESTAMPDIFF(MONTH,patreonTimer,NOW())<patreonMonths),1,0) as patreon FROM cowoncy LEFT JOIN user ON cowoncy.id = user.id LEFT JOIN patreons ON user.uid = patreons.uid WHERE cowoncy.id = "+msg.author.id+";";
-		sql += `SELECT name,nickname,animal.pid FROM user INNER JOIN pet_team ON user.uid = pet_team.uid INNER JOIN pet_team_animal ON pet_team.pgid = pet_team_animal.pgid INNER JOIN animal ON pet_team_animal.pid = animal.pid
+		sql += `SELECT name,nickname,animal.pid FROM user INNER JOIN pet_team ON user.uid = pet_team.uid and pet_team.active = 1 INNER JOIN pet_team_animal ON pet_team.pgid = pet_team_animal.pgid INNER JOIN animal ON pet_team_animal.pid = animal.pid
 				WHERE user.id = ${p.msg.author.id};`;
 		sql += "SELECT *,TIMESTAMPDIFF(HOUR,claim,NOW()) as time FROM lootbox WHERE id = "+msg.author.id+";";
 		sql += "SELECT uid,activecount,gname,type FROM user NATURAL JOIN user_gem NATURAL JOIN gem WHERE id = "+msg.author.id+" AND activecount > 0;";


### PR DESCRIPTION
Lets you stash / swap between a second team layout.  All commands run off the active team like they do now, inactive teams count towards rankings and are part of the pool of random teams.

EXP is only given to pets on the active team and weapons are still tied to pets, to keep things simple.  You can (currently) have a pet in both your active and inactive team.  Streaks are still tied to the team so people can test new layouts without losing their streak.

First time you run the swapactive command (not sold on the name but didn't want to tie down "swap") it'll mark your team as inactive and treat it like you have no team, will have to add a pet to create a new team like creating a team currently.
