### PR TITLE
Missing npm package in package.JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "systeminformation": "^4.4.1",
     "translate-google": "^1.3.5",
     "urban-dictionary": "^2.2.1",
+    "utf-8-validate": "^5.0.2",
     "weeb.js": "^1.6.2",
     "workerpool": "^3.1.2",
     "ws": "^7.1.1"


### PR DESCRIPTION
This is to add an additional package that is missing from the packages.json file that gets flagged when running "npm install" on a fresh install. This package is a requirement for Eris