### PR TITLE
Allow users to hit a 100 with owo bell

### DIFF
--- a/src/commands/commandList/patreon/strengthtest.js
+++ b/src/commands/commandList/patreon/strengthtest.js
@@ -68,7 +68,7 @@ module.exports = new CommandInterface({
 
 		collector.on('collect', async function(emoji){
 			collector.stop();
-			let rand = Math.random();
+			let rand = Math.floor(Math.random() * 101) / 100;
 			if(geist==p.msg.author.id){
 				rand = (80+rand*21)/100;
 			}


### PR DESCRIPTION
Resolves issue #115. There was a bug in the `owo bell` command that made it impossible for users to actually hit a 100. `Math.rand()` returns a number from zero up to, but not including, 1. This change sets the rand variable to return a number between 0-1 inclusive.