### PR TITLE
Battle Bugfixes

### DIFF
--- a/src/commands/commandList/battle/BuffInterface.js
+++ b/src/commands/commandList/battle/BuffInterface.js
@@ -108,8 +108,7 @@ module.exports = class BuffInterface{
 		if(this.duration<=0){
 			for(let i=0;i<animal.buffs.length;i++){
 				if(animal.buffs[i].id == this.id && animal.buffs[i].from.pid==this.from.pid){
-					animal.buffs.splice(i,1);
-					i--;
+					animal.buffs[i].markedForDeath = true;
 				}
 			}
 		}

--- a/src/commands/commandList/battle/buffs/flame.js
+++ b/src/commands/commandList/battle/buffs/flame.js
@@ -25,8 +25,8 @@ module.exports = class Flame extends BuffInterface{
 		if(tags.flame) return;
 		let logs = new Logs();
 		for(let i in animal.buffs){
-			if(animal.buffs[i].id == this.id){
-				animal.buffs.splice(i,1);
+			if(animal.buffs[i].id == this.id && !animal.buffs[i].markedForDeath){
+				animal.buffs[i].markedForDeath = true;
 				let damage = WeaponInterface.getDamage(this.from.stats.mag,this.stats[1]/100);
 				damage = WeaponInterface.inflictDamage(this.from,animal,damage,WeaponInterface.MAGICAL,{...tags,flame:true});
 				logs.push(`[FLAME] Exploded and damaged ${animal.nickname} for ${damage.amount} HP`, damage.logs);

--- a/src/commands/commandList/battle/passives/lifesteal.js
+++ b/src/commands/commandList/battle/passives/lifesteal.js
@@ -23,7 +23,7 @@ module.exports = class Lifesteal extends PassiveInterface{
 	}
 
 	postAttack(animal,attackee,damage,type,tags){
-		if(tags.lifesteal) return;
+		if(tags.lifesteal || animal.stats.hp[0]<=0 ) return;
 		let logs = new Log();
 		let totalDamage = damage.reduce((a,b)=>a+b,0);
 		let heal = totalDamage*this.stats[0]/100;

--- a/src/commands/commandList/battle/util/battleUtil.js
+++ b/src/commands/commandList/battle/util/battleUtil.js
@@ -518,6 +518,8 @@ async function executeBattle(p,msg,action,setting){
 	/* Post turn */
 	postTurn(battle.player.team,battle.enemy.team,action);
 	postTurn(battle.enemy.team,battle.player.team,eaction);
+	/* Remove marked buffs */
+	removeBuffs(battle.player.team,battle.enemy.team);
 
 	/* check if the battle is finished */
 	let enemyWin = teamUtil.isDead(battle.player.team);
@@ -616,6 +618,8 @@ var calculateAll = exports.calculateAll = function(p,battle,logs = []){
 	/* Post turn */
 	battleLogs = battleLogs.concat(postTurn(battle.player.team,battle.enemy.team,[weapon,weapon,weapon]));
 	battleLogs = battleLogs.concat(postTurn(battle.enemy.team,battle.player.team,eaction));
+	/* Remove marked buffs */
+	removeBuffs(battle.player.team,battle.enemy.team);
 
 	/* Save only the HP and WP states (will need to save buff status later) */
 	let state = saveStates(battle);
@@ -884,7 +888,6 @@ function postTurn(team,enemy,action){
 	let logs = [];
 	for(let i in team){
 		let animal= team[i];
-		// Start from the top down to avoid splice errors
 		let j = animal.buffs.length;
 		while(j--){
 			let log = animal.buffs[j].postTurn(animal,team,enemy,action[i]);
@@ -906,6 +909,40 @@ function postTurn(team,enemy,action){
 	}
 
 	return logs;
+}
+
+/* strip buffs after turn fully processed */
+function removeBuffs(team, enemy) {
+	for(let i in team){
+		let animal= team[i];
+		let j = animal.buffs.length;
+		while(j--){
+			if (animal.buffs[j].markedForDeath) {
+				animal.buffs.splice(j,1);
+			}
+		}
+		j = animal.debuffs.length;
+		while(j--){
+			if (animal.debuffs[j].markedForDeath) {
+				animal.debuffs.splice(j,1);
+			}
+		}
+	}
+	for(let i in enemy){
+		let animal= enemy[i];
+		let j = animal.buffs.length;
+		while(j--){
+			if (animal.buffs[j].markedForDeath) {
+				animal.buffs.splice(j,1);
+			}
+		}
+		j = animal.debuffs.length;
+		while(j--){
+			if (animal.debuffs[j].markedForDeath) {
+				animal.debuffs.splice(j,1);
+			}
+		}
+	}
 }
 
 /* finish battle */


### PR DESCRIPTION
This is a ~~crab rave~~ dagger nerf. And a Lifesteal nerf.

In all seriousness, after review I didn't like how I fixed this in the battle changes PR and finally had time to fix it in a way that I feel is right.  All buffs will stick around until all post-turn is handled - this cleans up stuff like freeze handling, poison / flame ticking after taunt expires, and other funky buff expiration quirks.

Also fixes LS / kkaze orbs, not sorry to everyone who's abusing that atm.