### PR TITLE
A couple more aliases

### DIFF
--- a/src/commands/commandList/economy/quest.js
+++ b/src/commands/commandList/economy/quest.js
@@ -18,7 +18,7 @@ const questJson = require('../../../data/quests.json');
 
 module.exports = new CommandInterface({
 
-	alias:["quest"],
+	alias:["quest","q"],
 
 	args:"{rr} {num}",
 

--- a/src/commands/commandList/ranking/me.js
+++ b/src/commands/commandList/ranking/me.js
@@ -71,7 +71,7 @@ async function display(p,con, msg, args){
 			else if(args[i]=== "cowoncy"||args[i]==="money"||args[i]==="c"||args[i]==="m"||args[i]==="cash") money = true;
 			else if(args[i]==="cookies"||args[i]==="cookie"||args[i]=== "rep"||args[i]==="r") rep = true;
 			else if(args[i]==="pets"||args[i]==="pet") pet = true;
-			else if(args[i]==="huntbot"||args[i]==="hb"||args[i]==="autohunt") huntbot= true;
+			else if(args[i]==="huntbot"||args[i]==="hb"||args[i]==="autohunt"||args[i]==="ah") huntbot= true;
 			else if(args[i]==="luck"||args[i]==="pray") luck = true;
 			else if(args[i]==="curse") curse = true;
 			else if(args[i]==="battle"||args[i]==="streak") battle = true;

--- a/src/commands/commandList/ranking/top.js
+++ b/src/commands/commandList/ranking/top.js
@@ -69,7 +69,7 @@ async function display(p,con, msg, args){
 			else if(args[i]=== "cowoncy"||args[i]==="money"||args[i]==="m"||args[i]==="c"||args[i]==="cash") money = true;
 			else if(args[i]==="cookies"||args[i]==="cookie"||args[i]==="rep"||args[i]==="r") rep = true;
 			else if(args[i]==="pets"||args[i]==="pet") pet = true;
-			else if(args[i]==="huntbot"||args[i]==="hb") huntbot = true;
+			else if(args[i]==="huntbot"||args[i]==="hb"||args[i]==="autohunt"||args[i]==="ah") huntbot = true;
 			else if(args[i]==="luck"||args[i]==="pray") luck = true;
 			else if(args[i]==="curse") curse = true;
 			else if(args[i]==="battle"||args[i]==="streak") battle = true;

--- a/src/commands/commandList/zoo/autohunt.js
+++ b/src/commands/commandList/zoo/autohunt.js
@@ -18,7 +18,7 @@ const animals = require('../../../../../tokens/owo-animals.json');
 
 module.exports = new CommandInterface({
 
-	alias:["autohunt","huntbot","hb"],
+	alias:["autohunt","huntbot","hb","ah"],
 
 	args:"{cowoncy}",
 

--- a/src/commands/commandList/zoo/zoo.js
+++ b/src/commands/commandList/zoo/zoo.js
@@ -27,7 +27,7 @@ initDisplay();
 
 module.exports = new CommandInterface({
 
-	alias:["zoo"],
+	alias:["zoo","z"],
 
 	args:"{display}",
 


### PR DESCRIPTION
`ah` for `autohunt` (also added to the `my` and `top` commands)
`z` for `zoo` (which was an option in the `my` and `top` commands, but not for the `zoo` command itself)
`q` for `quest`