### PR TITLE
Added discriminator in the quest embed

### DIFF
--- a/src/commands/commandList/economy/quest.js
+++ b/src/commands/commandList/economy/quest.js
@@ -136,7 +136,7 @@ function constructEmbed(p,afterMid,quests){
 			"text": "Next quest in: "+afterMid.hours+" H "+afterMid.minutes+" M "+afterMid.seconds+" S"
 		},
 		"author": {
-			"name": p.msg.author.username+"'s Quest Log",
+			"name": `${p.msg.author.username}#${p.msg.author.discriminator}'s Quest Log`,
 			"icon_url":p.msg.author.avatarURL
 		},
 		"description":quests.text


### PR DESCRIPTION
"When the bot reply for owoquest command, it will say full name and tag from the user
EG : L.O.V.E#3602's quest log Instead of "L.O.V.E's quest log"
This will help the list keeper can keep list more easy and they can even keep list when the bot is lagging"
That's a suggestion that I found recently and I think it's quite good :) also it got a very good upvote/downvote ratio