### PR TITLE
Increased max amount of give to 10 mil

### DIFF
--- a/src/commands/commandList/economy/give.js
+++ b/src/commands/commandList/economy/give.js
@@ -48,7 +48,7 @@ module.exports = new CommandInterface({
 			return;
 		}
 
-		if(amount>1000000) amount = 1000000;
+		if(amount>10000000) amount = 10000000;
 
 
 		//Check if valid user


### PR DESCRIPTION
Again implementing a suggestion I found recently, this time from nico: "This most likely has been suggested before but please increase the give cap from 1,000,000 to like 5,000,000 or even 10,000,000. Hosting events like a lottery where we get 60mil or whatever is just so much work paying out the winner and its not fun now that we cant drop money anymore." I think the reasons he provides are good, so why not :p