### PR TITLE
Updated help for the deprecated drop command

### DIFF
--- a/src/commands/commandList/gamble/drop.js
+++ b/src/commands/commandList/gamble/drop.js
@@ -16,7 +16,7 @@ module.exports = new CommandInterface({
 
 	args:"{amount}",
 
-	desc:"Drop some cowoncy in a channel with 'owo drop {amount}'! Users can pick it up with 'owo pickup {amount}' If you try to pick up more than what's on the floor, you'll lose that amount! Be careful!",
+	desc:"This command is now deprecated. ~~Drop some cowoncy in a channel with 'owo drop {amount}'! Users can pick it up with 'owo pickup {amount}' If you try to pick up more than what's on the floor, you'll lose that amount! Be careful!~~",
 
 	example:["owo drop 3000"],
 

--- a/src/commands/commandList/utils/help.js
+++ b/src/commands/commandList/utils/help.js
@@ -87,7 +87,7 @@ function display(p){
 			{"name":"🌱 Animals",
 				"value":"`zoo`  `hunt`  `sell`  `battle`  `inv`  `equip`  `autohunt`  `owodex`  `lootbox`  `crate`  `battlesetting`  `team`  `weapon`  `rename` `dismantle`"},
 			{"name":"🎲 Gambling",
-				"value":"`slots`  `coinflip`  `lottery`  `blackjack`  `drop`"},
+				"value":"`slots`  `coinflip`  `lottery`  `blackjack`"},
 			{"name":"🎱 Fun",
 				"value":"`8b`  `define`  `gif`  `pic`  `translate`  `roll`  `choose`  `bell`"},
 			{"name":"🎭 Social",


### PR DESCRIPTION
Updated the `help` commands since `drop` is now deprecated.

It is no longer listed in the general `help` command, and when `help` is used on `drop` specifically, the previous description is crossed out and is preceded by a statement about its deprecated status.