### PR TITLE
Fixed bug with lifesteal / kamikazi orbs reviving pets

### DIFF
--- a/src/commands/commandList/battle/passives/lifesteal.js
+++ b/src/commands/commandList/battle/passives/lifesteal.js
@@ -23,7 +23,7 @@ module.exports = class Lifesteal extends PassiveInterface{
 	}
 
 	postAttack(animal,attackee,damage,type,tags){
-		if(tags.lifesteal || animal.stats.hp[0]<=0 ) return;
+		if (tags.lifesteal || tags.kamikaze || animal.stats.hp[0]<=0) return;
 		let logs = new Log();
 		let totalDamage = damage.reduce((a,b)=>a+b,0);
 		let heal = totalDamage*this.stats[0]/100;


### PR DESCRIPTION
~~move postAttack/postAttacked to process after damage is applied to prevent pets from rising from the dead~~

Updated to simplify this because the bug is becoming more commonly known. _Technically_ this breaks lifesteal on turns where you kill a target with a kamikaze passive, but that can be dealt with later.