### PR TITLE
added ability to censor all opposing team / pet names with random names

### DIFF
--- a/src/commands/commandList/battle/battle.js
+++ b/src/commands/commandList/battle/battle.js
@@ -102,7 +102,7 @@ async function changeType(p,type){
 }
 
 async function parseSettings(p){
-	let sql = `SELECT logs,auto,display,speed from user INNER JOIN battle_settings ON user.uid = battle_settings.uid WHERE id = ${p.msg.author.id};`;
+	let sql = `SELECT logs,auto,display,speed,censor from user INNER JOIN battle_settings ON user.uid = battle_settings.uid WHERE id = ${p.msg.author.id};`;
 	let result = await p.query(sql);
 	return parseSetting(result);
 }
@@ -113,6 +113,7 @@ function parseSetting(query){
 	let speed = "short";
 	let showLogs = false;
 	let instant = false;
+	let censor = false;
 
 	if(query[0]){
 		//if(query[0].auto==1)
@@ -134,11 +135,14 @@ function parseSetting(query){
 			auto = true;
 			speed = "instant";
 		}
+		if (query[0].censor==1){
+			censor = true;
+		}
 	}
 
 	if(auto&&(speed=="short"||speed=="instant")){
 		instant = true;
 	}
 
-	return {auto,display,speed,instant,showLogs};
+	return {auto,display,speed,instant,showLogs,censor};
 }

--- a/src/commands/commandList/battle/battleSetting.js
+++ b/src/commands/commandList/battle/battleSetting.js
@@ -37,7 +37,7 @@ module.exports = new CommandInterface({
 })
 
 async function display(p){
-	let sql = `SELECT logs,auto,display,speed from user INNER JOIN battle_settings ON user.uid = battle_settings.uid WHERE id = ${p.msg.author.id};`;
+	let sql = `SELECT logs,auto,display,speed,censor from user INNER JOIN battle_settings ON user.uid = battle_settings.uid WHERE id = ${p.msg.author.id};`;
 	let result = await p.query(sql);
 
 	let settings = parseSettings(result);
@@ -48,6 +48,7 @@ async function display(p){
 	text += "**Speed = ** `"+settings.speed+"`";
 	if(settings.showLogs||!settings.auto) text += "~~";
 	text += "\n**Logs = ** `"+settings.showLogs+"`";
+	text += "\n**Censor = ** `"+settings.censor+"`";
 
 	let embed = {
 		"color":p.config.embed_color,
@@ -116,11 +117,21 @@ async function changeSettings(p){
 		}else if(args[1]=='link'){
 			setting = 2;
 		}else{
-			p.errorMsg(", the log settings can only be `true`, or `false`!");
+			p.errorMsg(", the log settings can only be `link`, `true`, or `false`!");
+			return;
+		}
+	}else if(args[0]=='censor'){
+		field = 'censor';
+		if(args[1]=='false'){
+			setting = 0;
+		}else if(args[1]=='true'){
+			setting = 1;
+		}else{
+			p.errorMsg(", the censor settings can only be `true`, or `false`!");
 			return;
 		}
 	}else{
-		p.errorMsg(", the display settings can only be `logs`, `display`, or `speed`!");
+		p.errorMsg(", the display settings can only be `logs`, `display`, `speed`, or `censor`!");
 		return;
 	}
 
@@ -144,6 +155,7 @@ function parseSettings(query){
 	let display = "image";
 	let speed = "short";
 	let logs = false;
+	let censor = false;
 
 	if(query[0]){
 		//if(query[0].auto==1)
@@ -162,6 +174,8 @@ function parseSettings(query){
 			logs = true;
 		else if(query[0].logs==2)
 			logs = "link";
+		if(query[0].censor==1)
+			censor = true;
 	}
-	return {auto,display,speed,showLogs:logs};
+	return {auto,display,speed,showLogs:logs,censor};
 }

--- a/src/commands/commandList/battle/util/battleUtil.js
+++ b/src/commands/commandList/battle/util/battleUtil.js
@@ -77,7 +77,7 @@ var getBattle = exports.getBattle = async function(p,setting){
 
 	let result = await p.query(sql);
 
-	let censor = true;
+	let censor = setting.censor;
 
 	/* Grab pgid */
 	let pgid = result[0][0]?result[0][0].pgid:undefined;
@@ -115,7 +115,7 @@ var getBattle = exports.getBattle = async function(p,setting){
 		highestStreak:result[0][0].highest_streak,
 		team:pTeam};
 	let enemy = {pgid:epgid,
-		name:(censor&&result[1][0].ptcensor==1)?"Censored":result[1][0].tname,
+		name:censor?p.global.generateRandomName(3):(result[1][0].ptcensor==1)?"Censored":result[1][0].tname,
 		team:eTeam};
 	let teams = {player,enemy};
 
@@ -162,7 +162,7 @@ exports.initBattle = async function(p,setting){
 
 	let result = await p.query(sql);
 
-	let censor = true;
+	let censor = setting.censor;
 
 	pgid = result[1][0]?result[1][0].pgid:undefined;
 	let epgid = result[0][0]?result[0][0].pgid:undefined;
@@ -187,7 +187,7 @@ exports.initBattle = async function(p,setting){
 		highestStreak:result[1][0].highest_streak,
 		team:pTeam};
 	let enemy = {pgid:epgid,
-		name:(censor&&result[0][0].ptcensor==1)?"Censored":result[0][0].tname,
+		name:censor?p.global.generateRandomName(3):(result[0][0].ptcensor==1)?"Censored":result[0][0].tname,
 		team:eTeam};
 	let teams = {player,enemy};
 

--- a/src/commands/commandList/battle/util/teamUtil.js
+++ b/src/commands/commandList/battle/util/teamUtil.js
@@ -344,8 +344,9 @@ function parseTeam(p,animals,weapons,censor=false){
 		if(!used.includes(animal.pid)){
 			used.push(animal.pid);
 			let animalObj = p.global.validAnimal(animal.name);
-			let nickname = (censor&&animal.acensor==1)?"Censored":animal.nickname;
+			let nickname = (animal.acensor==1)?"Censored":animal.nickname;
 			if(!nickname) nickname = animalObj.name;
+			if (censor) nickname = p.global.generateRandomName(1);
 			result.push({
 				pid:animal.pid,
 				animal:animalObj,

--- a/src/utils/global.js
+++ b/src/utils/global.js
@@ -249,6 +249,11 @@ exports.getTotalShardCount = function(){
 	});
 }
 
+/* Generates a random name with the provided word count */
+exports.generateRandomName = function (wordCount) {
+	return namor.generate({ words: wordCount, saltLength: 0, separator:' ' });
+}
+
 /* Converts name to more kid-friendly */
 exports.filteredName = function (name) {
 


### PR DESCRIPTION
`owo bs censor = true`

Also retrofitted the base censor logic to reflect it always being enabled to avoid having two "censor" variables like some kind of a madman

sql: `alter table battle_settings add column censor tinyint(4) default '0';`