### PR TITLE
Update inventory.js

### DIFF
--- a/src/commands/commandList/shop/inventory.js
+++ b/src/commands/commandList/shop/inventory.js
@@ -88,7 +88,7 @@ function addToString(items){
 	let count = 0;
 	for(let i=0;i<items.length;i++){
 		let item = items[i];
-		text += "`"+((item.id<9)?"0":"")+item.id+"`"+item.emoji+ shopUtil.toSmallNum(item.count,digits);
+		text += "`"+((item.id<10)?"0":"")+((item.id<100)?"0":"")+item.id+"`"+item.emoji+ shopUtil.toSmallNum(item.count,digits);
 		count++;
 		if(count==4){
 			text += "\n";


### PR DESCRIPTION
Aligned shop ids by adding an extra '0' to 2 digit numbers. Also corrected item.id<9 to item.id<10 in case there ever is an inventory item with id 9.