### PR TITLE
Removes Merch from help

### DIFF
--- a/src/commands/commandList/utils/help.js
+++ b/src/commands/commandList/utils/help.js
@@ -99,7 +99,7 @@ function display(p){
 			{"name":"🤗 Actions",
 				"value":uEmotes+"  `bully`"},
 			{"name":"🔧 Utility",
-				"value":"`ping`  `stats`  `link`  `guildlink`  `disable`  `censor`  `patreon`  `announcement`  `rules`  `suggest`  `shards`  `math`  `merch`  `color`  `prefix`"},
+				"value":"`ping`  `stats`  `link`  `guildlink`  `disable`  `censor`  `patreon`  `announcement`  `rules`  `suggest`  `shards`  `math`  `color`  `prefix`"},
 		]
 	};
 


### PR DESCRIPTION
There is not a merch command, but it is listed in help. This change removes it. 

Mentioned in
https://github.com/ChristopherBThai/Discord-OwO-Bot/issues/244