### PR TITLE
Updates the embed for lottery to 150k max

### DIFF
--- a/src/commands/commandList/gamble/lottery.js
+++ b/src/commands/commandList/gamble/lottery.js
@@ -89,7 +89,7 @@ async function bet(con,msg,args,global,p){
 			chance = Math.trunc(chance*100)/100
 
 		let embed = {
-				"description": "Lottery ends once a day! The maximum lottery submission is 100K cowoncy!",
+				"description": "Lottery ends once a day! The maximum lottery submission is 150K cowoncy!",
 				"color": p.config.embed_color,
 				"timestamp": new Date(),
 				"footer": {


### PR DESCRIPTION
It was mentioned in a suggestion that the embed states the previous value of 100k instead of the new max value.

Suggestion link: https://discord.com/channels/420104212895105044/519778148888346635/931497427800825886