### PR TITLE
Add a weapon's ID to reroll message

### DIFF
--- a/src/commands/commandList/battle/util/rerollUtil.js
+++ b/src/commands/commandList/battle/util/rerollUtil.js
@@ -209,7 +209,7 @@ function createEmbed(p,oldWeapon, newWeapon){
 }
 
 function parseDescription(title,weapon){
-	let desc = "**ID:** `${weapon.uwid}`\n"
+	let desc = `**ID:** \`${weapon.uwid}\`\n`
 	desc += `**Quality:** ${weapon.rank.emoji} ${weapon.avgQuality}%\n`;
 	desc += `**WP Cost:** ${Math.ceil(weapon.manaCost)} <:wp:531620120976687114>`;
 	desc += `\n**Description:** ${weapon.desc}\n`;

--- a/src/commands/commandList/battle/util/rerollUtil.js
+++ b/src/commands/commandList/battle/util/rerollUtil.js
@@ -209,7 +209,8 @@ function createEmbed(p,oldWeapon, newWeapon){
 }
 
 function parseDescription(title,weapon){
-	let desc = `**Quality:** ${weapon.rank.emoji} ${weapon.avgQuality}%\n`;
+	let desc = "**ID:** `${weapon.uwid}`\n"
+	desc += `**Quality:** ${weapon.rank.emoji} ${weapon.avgQuality}%\n`;
 	desc += `**WP Cost:** ${Math.ceil(weapon.manaCost)} <:wp:531620120976687114>`;
 	desc += `\n**Description:** ${weapon.desc}\n`;
 	if(weapon.buffList.length>0){


### PR DESCRIPTION
Sometimes when I reroll a lot of stuff at once I can lose track of what I am rerolling (two of the same weapon type for example) it would be nice to include the weapon id in the embed to distinguish weapons more easily and improve clarity.