### PR TITLE
Incorrect passive emoji fix and cleaning

### DIFF
--- a/src/commands/commandList/battle/PassiveInterface.js
+++ b/src/commands/commandList/battle/PassiveInterface.js
@@ -5,118 +5,121 @@
  * For more information, see README.md and LICENSE
  */
 
-const ranks = [0.2, 0.2, 0.2, 0.2, 0.14, 0.05, 0.01];
+const ranks = [0.21, 0.41, 0.61, 0.81, 0.95, 1];
+
 module.exports = class PassiveInterface {
-	constructor(qualities, noCreate) {
-		this.init();
-		if (noCreate) return;
+    constructor(qualities, noCreate) {
+        this.init();
+        if (noCreate) { return; }
 
-		if (!qualities) qualities = this.randomQualities();
+        if (!qualities) { qualities = this.randomQualities(); }
 
-		let avgQuality = qualities.reduce((a, b) => a + b, 0) / qualities.length;
-		let emoji = this.getEmoji(avgQuality);
-		let stats = this.toStats(qualities);
+        const avgQuality = qualities.reduce((a, b) => a + b, 0) / qualities.length;
+        const emoji = this.getEmoji(avgQuality);
+        const stats = this.toStats(qualities);
 
-		/* Construct desc */
-		let desc = this.statDesc;
-		for (var i = 0; i < stats.length; i++) {
-			desc = desc.replace('?', stats[i]);
-		}
-		/* Check if it has enough emojis */
-		if (this.emojis.length != 7)
-			throw new Error(`[${args.id}] does not have 7 emojis`);
+        /* Construct desc */
+        let desc = this.statDesc;
+        for (let i = 0; i < stats.length; i++) {
+            desc = desc.replace('?', stats[i]);
+        }
+        /* Check if it has enough emojis */
+        if (this.emojis.length !== 7) { throw new Error(`[${args.id}] does not have 7 emojis`); }
 
-		this.avgQuality = avgQuality;
-		this.qualities = qualities;
-		this.emoji = emoji;
-		this.stats = stats;
-		this.desc = desc;
-		this.sqlStat = qualities.join(',');
-	}
+        this.avgQuality = avgQuality;
+        this.qualities = qualities;
+        this.emoji = emoji;
+        this.stats = stats;
+        this.desc = desc;
+        this.sqlStat = qualities.join(',');
+    }
 
-	randomQualities() {
-		var qualities = [];
-		for (var i = 0; i < this.qualityList.length; i++)
-			qualities.push(Math.trunc(Math.random() * 101));
-		return qualities;
-	}
+    randomQualities() {
+        const qualities = [];
+        for (let i = 0; i < this.qualityList.length; i++) { qualities.push(Math.trunc(Math.random() * 101)); }
+        return qualities;
+    }
 
-	getEmoji(quality) {
-		/* If there are multiple quality, get avg */
-		if (typeof quality == 'string') {
-			quality = parseInt(quality.split(','));
-			quality = quality.reduce((a, b) => a + b, 0) / quality.length;
-		}
+    getEmoji(quality) {
+        /* If there are multiple quality, get avg */
+        if (typeof quality === 'string') {
+            quality = quality.split(',');
+            quality = quality.reduce((a, b) => parseInt(a) + parseInt(b), 0) / quality.length;
+        }
 
-		quality /= 100;
+        quality /= 100;
 
-		/* Get correct rank */
-		var count = 0;
-		for (var i = 0; i < ranks.length; i++) {
-			count += ranks[i];
-			if (quality <= count) return this.emojis[i];
-		}
-		return this.emojis[0];
-	}
+        /* Get correct rank */
+        for (let rankIndex = 0; rankIndex < ranks.length; rankIndex++) {
+            const rankQuality = ranks[rankIndex];
+            const previousRankQuality = ranks[rankIndex - 1] || 0;
 
-	toStats(qualities) {
-		if (qualities.length != this.qualityList.length)
-			throw new Error(
-				'Array size does not match in toStats. Passive id:' + this.id
-			);
-		var stats = [];
-		for (var i = 0; i < qualities.length; i++) {
-			let quality = qualities[i];
-			if (quality > 100) quality = 100;
-			if (quality < 0) quality = 0;
-			let min = this.qualityList[i][0];
-			let max = this.qualityList[i][1];
+            if (quality > previousRankQuality && quality < rankQuality) {
+                return this.emojis[rankIndex];
+            }
+        }
+        return this.emojis[0];
+    }
 
-			/* rounds to 2 decimal places */
-			stats.push(Math.round((min + (max - min) * (quality / 100)) * 100) / 100);
-		}
-		return stats;
-	}
+    toStats(qualities) {
+        if (qualities.length !== this.qualityList.length) {
+            throw new Error(
+                `Array size does not match in toStats. Passive id:${this.id}`
+            );
+        }
+        const stats = [];
+        for (let i = 0; i < qualities.length; i++) {
+            let quality = qualities[i];
+            if (quality > 100) { quality = 100; }
+            if (quality < 0) { quality = 0; }
+            const min = this.qualityList[i][0];
+            const max = this.qualityList[i][1];
 
-	alterStats(stats) {}
+            /* rounds to 2 decimal places */
+            stats.push(Math.round((min + (max - min) * (quality / 100)) * 100) / 100);
+        }
+        return stats;
+    }
 
-	static get getID() {
-		return new this(null, true).id;
-	}
-	static get disabled() {
-		return new this(null, true).disabled;
-	}
+    alterStats(stats) { }
 
-	/* Before a turn executes */
-	preTurn(animal, ally, enemy, action) {}
-	/* After a turn executes */
-	postTurn(animal, ally, enemy, action) {}
+    static get getID() {
+        return new this(null, true).id;
+    }
+    static get disabled() {
+        return new this(null, true).disabled;
+    }
 
-	/* If the passive owner is attacking*/
-	attack(animal, attackee, damage, type, last) {}
-	/* If the passive owner is attacked */
-	attacked(animal, attacker, damage, type, last) {}
-	/* If the passive owner is healing */
-	heal(animal, healer, amount, tag) {}
-	/* If the passive owner is healed */
-	healed(animal, healer, amount, tag) {}
-	/* If the passive owner is replenishing */
-	replenish(animal, healer, amount, tag) {}
-	/* If the passive owner is replenished */
-	replenished(animal, healer, amount, tag) {}
-	/* If the passive owner is attacking (after bonus damage) */
-	postAttack(animal, attackee, damage, type, last) {}
-	/* If the passive owner is attacked (after bonus damage) */
-	postAttacked(animal, attacker, damage, type, last) {}
-	/* If the passive owner is healing(after bonus heal) */
-	postHeal(animal, healer, amount, tag) {}
-	/* If the passive owner is healed (after bonus heal) */
-	postHealed(animal, healer, amount, tag) {}
-	/* If the passive owner is replenishing (after bonus heal) */
-	postReplenish(animal, healer, amount, tag) {}
-	/* If the passive owner is replenished (after bonus heal) */
-	postReplenished(animal, healer, amount, tag) {}
+    /* Before a turn executes */
+    preTurn(animal, ally, enemy, action) { }
+    /* After a turn executes */
+    postTurn(animal, ally, enemy, action) { }
 
-	/* If the passive owner is allowed to attack */
-	canAttack(me, ally, enemy, action, result) {}
+    /* If the passive owner is attacking*/
+    attack(animal, attackee, damage, type, last) { }
+    /* If the passive owner is attacked */
+    attacked(animal, attacker, damage, type, last) { }
+    /* If the passive owner is healing */
+    heal(animal, healer, amount, tag) { }
+    /* If the passive owner is healed */
+    healed(animal, healer, amount, tag) { }
+    /* If the passive owner is replenishing */
+    replenish(animal, healer, amount, tag) { }
+    /* If the passive owner is replenished */
+    replenished(animal, healer, amount, tag) { }
+    /* If the passive owner is attacking (after bonus damage) */
+    postAttack(animal, attackee, damage, type, last) { }
+    /* If the passive owner is attacked (after bonus damage) */
+    postAttacked(animal, attacker, damage, type, last) { }
+    /* If the passive owner is healing(after bonus heal) */
+    postHeal(animal, healer, amount, tag) { }
+    /* If the passive owner is healed (after bonus heal) */
+    postHealed(animal, healer, amount, tag) { }
+    /* If the passive owner is replenishing (after bonus heal) */
+    postReplenish(animal, healer, amount, tag) { }
+    /* If the passive owner is replenished (after bonus heal) */
+    postReplenished(animal, healer, amount, tag) { }
+
+    /* If the passive owner is allowed to attack */
+    canAttack(me, ally, enemy, action, result) { }
 };


### PR DESCRIPTION
The getEmoji() function sometimes showed incorrect passive for example: when the crit passive had qualities [100,99]. So I changed the logic to check between quality 'boundaries' instead of adding to the 'count' variable to get the rankQuality.

I also did some cleaning -> changed `var` to `const` `let`, '!=' to '!==' etc.

![image](https://user-images.githubusercontent.com/86320905/208294792-0806e823-005c-469e-a8fb-8a6322383644.png)
