### PR TITLE
potential fix for raw JSON output with conversions

### DIFF
--- a/src/commands/commandList/utils/math.js
+++ b/src/commands/commandList/utils/math.js
@@ -52,7 +52,7 @@ module.exports = new CommandInterface({
 				} else if (typeof result == 'object')
 					p.replyMsg(
 						mathEmoji,
-						p.replaceMentions(', the answer is: **' + JSON.stringify(result) + '**')
+						p.replaceMentions(', the answer is: **' + result.value + '**')
 					);
 				else p.replyMsg(mathEmoji, p.replaceMentions(', the answer is: **' + result + '**'));
 			})


### PR DESCRIPTION
Noticed an issue with trying to convert something like "60minutes to seconds" where the bot would output raw JSON (Ie check for `if (result.mathjs)` fails and falls to the `else if (typeof result == 'object')` block which then just outputs the raw JSON `result` object as opposed to `result.value`. I have no clue if this is a symptom of a larger issue or not, but the change provided here is a quick solution that does fix the issue described above. At the very least, let this draw your attention to this issue, and hopefully you can find a more elegant solution than this. 

Example:

Input:
> owo math 60minutes to seconds

Output:
```
the answer is: {"units":[{"unit":{"name":"seconds","base":{"dimensions":[0,0,1,0,0,0,0,0,0],"key":"TIME"},"prefixes":{"":{"name":"","value":1,"scientific":true},"deca":{"name":"deca","value":10,"scientific":false},"hecto":{"name":"hecto","value":100,"scientific":false},"kilo":{"name":"kilo","value":1000,"scientific":true},"mega":{"name":"mega","value":1000000,"scientific":true},"giga":{"name":"giga","value":1000000000,"scientific":true},"tera":{"name":"tera","value":1000000000000,"scientific":true},"peta":{"name":"peta","value":1000000000000000,"scientific":true},"exa":{"name":"exa","value":1000000000000000000,"scientific":true},"zetta":{"name":"zetta","value":1e+21,"scientific":true},"yotta":{"name":"yotta","value":1e+24,"scientific":true},"deci":{"name":"deci","value":0.1,"scientific":false},"centi":{"name":"centi","value":0.01,"scientific":false},"milli":{"name":"milli","value":0.001,"scientific":true},"micro":{"name":"micro","value":0.000001,"scientific":true},"nano":{"name":"nano","value":1e-9,"scientific":true},"pico":{"name":"pico","value":1e-12,"scientific":true},"femto":{"name":"femto","value":1e-15,"scientific":true},"atto":{"name":"atto","value":1e-18,"scientific":true},"zepto":{"name":"zepto","value":1e-21,"scientific":true},"yocto":{"name":"yocto","value":1e-24,"scientific":true}},"value":1,"offset":0,"dimensions":[0,0,1,0,0,0,0,0,0]},"prefix":{"name":"","value":1,"scientific":true},"power":1}],"dimensions":[0,0,1,0,0,0,0,0,0],"value":3600,"fixPrefix":true,"skipAutomaticSimplification":true}```