### PR TITLE
Fix for pstaff reviving pets and more

### DIFF
--- a/src/commands/commandList/battle/WeaponInterface.js
+++ b/src/commands/commandList/battle/WeaponInterface.js
@@ -262,8 +262,8 @@ module.exports = class WeaponInterface {
 	}
 
 	/* Get a random animal */
-	static getRandomAnimal(team, { hasDebuff } = {}) {
-		let list = team;
+	static getRandomAnimal(team, { hasDebuff, isAlive } = {}) {
+		let list = (isAlive && WeaponInterface.getAlive(team)) || team;
 
 		if (hasDebuff) {
 			list = list.filter(WeaponInterface.hasBadBuff);

--- a/src/commands/commandList/battle/weapons/pstaff.js
+++ b/src/commands/commandList/battle/weapons/pstaff.js
@@ -41,7 +41,7 @@ module.exports = class PStaff extends WeaponInterface {
 
 		/* Grab enemy with buff and ally with debuff */
 		let attacking = WeaponInterface.getAttacking(me, team, enemy, { hasBuff: true });
-		let ally = WeaponInterface.getRandomAnimal(team, { hasDebuff: true });
+		let ally = WeaponInterface.getRandomAnimal(team, { hasDebuff: true, isAlive: true });
 		if (!attacking && !ally) return this.attackPhysical(me, team, enemy);
 
 		let logs = new Logs();

--- a/src/commands/commandList/battle/weapons/pstaff.js
+++ b/src/commands/commandList/battle/weapons/pstaff.js
@@ -46,6 +46,17 @@ module.exports = class PStaff extends WeaponInterface {
 
 		let logs = new Logs();
 
+		/* deplete weapon points*/
+		let mana = WeaponInterface.useMana(me, this.manaCost, me, {
+			me,
+			allies: team,
+			enemies: enemy,
+		});
+		let manaLogs = new Logs();
+		manaLogs.push(`[PSTAFF] ${me.nickname} used ${mana.amount} WP`, mana.logs);
+
+		logs.addSubLogs(manaLogs);
+
 		/* Remove a buff from an enemy */
 		if (attacking) {
 			/* Remove buff */
@@ -106,16 +117,6 @@ module.exports = class PStaff extends WeaponInterface {
 			);
 		}
 
-		/* deplete weapon points*/
-		let mana = WeaponInterface.useMana(me, this.manaCost, me, {
-			me,
-			allies: team,
-			enemies: enemy,
-		});
-		let manaLogs = new Logs();
-		manaLogs.push(`[PSTAFF] ${me.nickname} used ${mana.amount} WP`, mana.logs);
-
-		logs.addSubLogs(manaLogs);
 		return logs;
 	}
 };


### PR DESCRIPTION
There was no check for HP for both of the sides `attacking` and `ally`. ~~This caused buffs being removed from dead enemy and dealing damage to them~~ (it seems like the `getAttacking` function gets only alive pets compared to `getRandomAnimal` function), debuffs being removed from dead ally and that caused reviving the pet.

Not sure if there are more changes needed, such as selecting different ally or enemy.