### PR TITLE
Make Rune of Celebration unsellable

### DIFF
--- a/src/commands/commandList/battle/util/rerollUtil.js
+++ b/src/commands/commandList/battle/util/rerollUtil.js
@@ -118,7 +118,7 @@ async function getWeapon(p, uwid) {
 			4000
 		);
 		return;
-	} else if (weapon.unsellable) {
+	} else if (weapon.unrerollable) {
 		p.errorMsg(", I can't reroll this weapon!", 4000);
 		return;
 	}

--- a/src/commands/commandList/battle/weapons/crune.js
+++ b/src/commands/commandList/battle/weapons/crune.js
@@ -31,6 +31,7 @@ module.exports = class CRune extends WeaponInterface {
 		this.qualityList = [];
 		this.manaRange = [200, 100];
 		this.buffList = [10];
+                this.unsellable = true;
 	}
 
 	attackWeapon(me, team, enemy) {

--- a/src/commands/commandList/battle/weapons/crune.js
+++ b/src/commands/commandList/battle/weapons/crune.js
@@ -31,7 +31,7 @@ module.exports = class CRune extends WeaponInterface {
 		this.qualityList = [];
 		this.manaRange = [200, 100];
 		this.buffList = [10];
-                this.unsellable = true;
+        this.unsellable = true;
 	}
 
 	attackWeapon(me, team, enemy) {

--- a/src/commands/commandList/battle/weapons/rune.js
+++ b/src/commands/commandList/battle/weapons/rune.js
@@ -31,6 +31,7 @@ module.exports = class Rune extends WeaponInterface {
 		this.passiveCount = 0;
 		this.qualityList = [[5, 15]];
 		this.unsellable = true;
+		this.unrerollable = true;
 	}
 
 	alterStats(stats) {


### PR DESCRIPTION
I feel like there is going to be the same issue as with Rune of the Forgotten which is also limited weapon and many people have accidentally sold it, so making Rune of Celebration unsellable would prevent that.