### PR TITLE
Increase time for rerolling a weapon

### DIFF
--- a/src/commands/commandList/battle/util/rerollUtil.js
+++ b/src/commands/commandList/battle/util/rerollUtil.js
@@ -142,7 +142,7 @@ async function sendMessage(p, oldWeapon, newWeapon, rrType, msg) {
 		[yesEmoji, noEmoji, retryEmoji].includes(emoji.name) && p.msg.author.id == userID;
 	let collector = p.reactionCollector.create(msg, filter, {
 		time: 900000,
-		idle: 120000,
+		idle: 300000,
 	});
 
 	collector.on('collect', async (emoji) => {


### PR DESCRIPTION
Sometimes people aren't sure if they should keep something and 2 minutes (after last interaction) is not a long time so I've decided to increase it to 5 minutes.