### PR TITLE
RStaff - remove debuffs from revived ally, Fix the sacrifice text when all pets are dead

### DIFF
--- a/src/commands/commandList/battle/passives/Sacrifice.js
+++ b/src/commands/commandList/battle/passives/Sacrifice.js
@@ -61,12 +61,17 @@ module.exports = class Sacrifice extends PassiveInterface {
 			}
 		}
 
-		healLogText = healLogText.slice(0, -2) + 'HP';
+		if (alive.length === 0) {
+			healLogText = '[SAC] did not find an ally to heal HP!';
+			repLogText = '[SAC] did not find an ally to replenish WP';
+		} else {
+			healLogText = healLogText.slice(0, -2) + 'HP';
+			repLogText = repLogText.slice(0, -2) + 'WP';
+		}
+		
 		logs.push(healLogText, healSubLogs);
-
-		repLogText = repLogText.slice(0, -2) + 'WP';
 		logs.push(repLogText, repSubLogs);
-
+		
 		return logs;
 	}
 };

--- a/src/commands/commandList/battle/weapons/ResurrectionStaff.js
+++ b/src/commands/commandList/battle/weapons/ResurrectionStaff.js
@@ -63,9 +63,10 @@ module.exports = class ResurrectionStaff extends WeaponInterface {
 			enemies: enemy,
 		});
 		
+		/* remove debuffs */
 		for (const i in dead.buffs) {
 			if (dead.buffs[i].debuff) {
-				dead.buffs.splice(i, 1)
+				dead.buffs.splice(i, 1);
 			}
 		}
 		

--- a/src/commands/commandList/battle/weapons/ResurrectionStaff.js
+++ b/src/commands/commandList/battle/weapons/ResurrectionStaff.js
@@ -62,6 +62,13 @@ module.exports = class ResurrectionStaff extends WeaponInterface {
 			allies: team,
 			enemies: enemy,
 		});
+		
+		for (const i in dead.buffs) {
+			if (dead.buffs[i].debuff) {
+				dead.buffs.splice(i, 1)
+			}
+		}
+		
 		logs.push(`[RSTAFF] ${me.nickname} revived ${dead.nickname} with ${heal.amount} HP`, heal.logs);
 
 		logs.addSubLogs(manaLogs);


### PR DESCRIPTION
When a pet is revived, debuffs such as poison immediately kill the pet once again so the revive is kind of pointless.

And when all pets are dead the sacrifice passive doesn't heal/replenish anything so it is displayed incorrectly in the logs. 
![image](https://github.com/ChristopherBThai/Discord-OwO-Bot/assets/86320905/1cde0521-3699-4201-8112-ebed7bd08d8f)
