### PR TITLE
fixed send cookie bug where in sender and receiver it shows same name 

### DIFF
--- a/src/commands/commandList/social/cookie.js
+++ b/src/commands/commandList/social/cookie.js
@@ -91,9 +91,9 @@ async function give(p, con, msg, args, global, send) {
 	result = await p.query(sql);
 	let text =
 		'**<a:cookieeat:423020737364885525> | ' +
-		p.getName() +
+		p.getUniqueName(user) +
 		'**! You got a cookie from **' +
-		p.getName() +
+		p.getUniqueName(msg.author) +
 		'**! *nom nom nom c:<*';
 	text = alterCookie.alter(p.msg.author.id, text, {
 		from: p.msg.author,


### PR DESCRIPTION
Fixed the username in send cookie response message where it was showing both receiver and user same name and updated it to show the unique name (username).