### PR TITLE
Update describe help information

### DIFF
--- a/src/commands/commandList/shop/describe.js
+++ b/src/commands/commandList/shop/describe.js
@@ -18,9 +18,9 @@ module.exports = new CommandInterface({
 
 	args: '',
 
-	desc: 'Describe an item from the shop!',
+	desc: 'Describe an item from your inventory!',
 
-	example: ['owo describe 2'],
+	example: ['owo describe 51'],
 
 	related: ['owo shop', 'owo inv', 'owo equip'],
 


### PR DESCRIPTION
Currently it states that it tells about an item from the shop, in my opinion saying inventory is more accurate. Additionally the example has 2 which results in "invalid id" as a reply, so I changed it to the id of the first common gem.