### PR TITLE
fix(global): remove redundant `@` from marriage proposal string

### DIFF
--- a/src/commands/commandList/social/marry.js
+++ b/src/commands/commandList/social/marry.js
@@ -148,9 +148,9 @@ async function propose(p, user, ringId) {
 			{
 				name: 'Once you have accepted, you will receive an extra lootbox or weapon crate when you both complete your daily!',
 				value:
-					'`owo am` to accept  |  `owo dm` to decline\nYou can divorce anytime with `owo divorce` or upgrade your marriage ring with `owo marry @' +
+					('`owo am` to accept  |  `owo dm` to decline\nYou can divorce anytime with `owo divorce` or upgrade your marriage ring with `owo marry @' +
 					p.getUniqueName(user) +
-					' {ringID}`',
+					' {ringID}`').replaceAll('@@', '@'),
 			},
 		],
 		color: p.config.embed_color,

--- a/src/utils/global.js
+++ b/src/utils/global.js
@@ -365,7 +365,7 @@ exports.getUniqueName = function (user) {
 	if (user.discriminator && user.discriminator !== '0') {
 		return `${user.username}#${user.discriminator}`;
 	} else {
-		return `${user.username}`;
+		return `@${user.username}`;
 	}
 };
 

--- a/src/utils/global.js
+++ b/src/utils/global.js
@@ -365,7 +365,7 @@ exports.getUniqueName = function (user) {
 	if (user.discriminator && user.discriminator !== '0') {
 		return `${user.username}#${user.discriminator}`;
 	} else {
-		return `@${user.username}`;
+		return `${user.username}`;
 	}
 };
 


### PR DESCRIPTION
I don't know if this is intended but the function returns `@` along with the already unique username if the user has updated to the new username (no discriminator). This causes the username to be returned as `@<username>` which turns into `@@<username>` wherever the message string already has an `@` before the username. (image attached)

![image](https://github.com/user-attachments/assets/bbb46e58-7869-4b83-a9ab-b3348581a191)

Another way to fix this would be to remove `@` from the message strings but I believe this is much simpler.