### PR TITLE
fix: add pages to owo pets command for full visibility

### DIFF
--- a/src/commands/commandList/battle/pet.js
+++ b/src/commands/commandList/battle/pet.js
@@ -4,31 +4,21 @@
  * This software is licensed under Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
  * For more information, see README.md and LICENSE
  */
-
 const CommandInterface = require('../../CommandInterface.js');
-
 const user_emote = require('../emotes/user_emote.js');
 const petUtil = require('./util/petUtil.js');
 
 module.exports = new CommandInterface({
 	alias: ['pets', 'pet'],
-
 	args: '',
-
 	desc: 'Displays your current pets! Add them by using them in battles!',
-
 	example: [],
-
 	related: ['owo battle', 'owo zoo'],
-
 	permissions: ['sendMessages', 'embedLinks', 'addReactions'],
-
 	group: ['animals'],
-
 	cooldown: 5000,
 	half: 200,
 	six: 600,
-
 	execute: async function (p) {
 		/* Is this a pat action? */
 		if (p.global.isUser(p.args[0])) {
@@ -36,7 +26,6 @@ module.exports = new CommandInterface({
 			user_emote.execute(p);
 			return;
 		}
-
 		if (p.args.length != 0) {
 			p.errorMsg(', Incorrect arguments');
 			return;
@@ -44,8 +33,18 @@ module.exports = new CommandInterface({
 
 		let animals = await petUtil.getAnimals(p);
 
-		let embed = petUtil.getDisplay(p, animals);
+		if (!animals || animals.length === 0) {
+			p.errorMsg(', You have no pets! Use your animals in battle to level them up!');
+			return;
+		}
 
-		await p.send(embed);
+		const totalPages = Math.max(1, Math.ceil(animals.length / petUtil.PAGE_SIZE));
+
+		new p.PagedMessage(
+			p,
+			(page) => petUtil.getDisplay(p, animals, page),
+			totalPages - 1,
+			{ idle: 60000 }
+		);
 	},
 });

--- a/src/commands/commandList/battle/util/petUtil.js
+++ b/src/commands/commandList/battle/util/petUtil.js
@@ -23,7 +23,7 @@ exports.getAnimals = async function (p) {
 			LEFT JOIN user_weapon_kills ON user_weapon.uwid = user_weapon_kills.uwid
 		WHERE animal.id = ${p.msg.author.id}
 			AND animal.xp > 0
-		ORDER BY xp DESC LIMIT 100;`;
+		ORDER BY animal.xp DESC;`;
 	let result = await p.query(sql);
 	let animals = teamUtil.parseTeam(result, result);
 	for (let i in animals) animalUtil.stats(animals[i]);

--- a/src/commands/commandList/battle/util/petUtil.js
+++ b/src/commands/commandList/battle/util/petUtil.js
@@ -4,14 +4,14 @@
  * This software is licensed under Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
  * For more information, see README.md and LICENSE
  */
-
 const teamUtil = require('./teamUtil.js');
 const animalUtil = require('./animalUtil.js');
 const WeaponInterface = require('../WeaponInterface.js');
 
+const PAGE_SIZE = 9;
+
 /* get and parse animals from the database */
 exports.getAnimals = async function (p) {
-	/* Query animals and weapons */
 	let sql = `SELECT 
 			animal.name, animal.nickname, animal.pid, animal.xp,
 			user_weapon.uwid, user_weapon.wid, user_weapon.stat, user_weapon.wear,
@@ -23,19 +23,18 @@ exports.getAnimals = async function (p) {
 			LEFT JOIN user_weapon_kills ON user_weapon.uwid = user_weapon_kills.uwid
 		WHERE animal.id = ${p.msg.author.id}
 			AND animal.xp > 0
-		ORDER BY xp DESC LIMIT 25;`;
-
+		ORDER BY xp DESC LIMIT 100;`;
 	let result = await p.query(sql);
-
-	/* Parse data */
 	let animals = teamUtil.parseTeam(result, result);
 	for (let i in animals) animalUtil.stats(animals[i]);
-
 	return animals;
 };
 
 /* Construct embed message */
-exports.getDisplay = function (p, animals) {
+exports.getDisplay = function (p, animals, page = 0) {
+	const totalPages = Math.max(1, Math.ceil(animals.length / PAGE_SIZE));
+	const pageAnimals = animals.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+
 	let embed = {
 		author: {
 			name: p.getName() + "'s pets",
@@ -43,13 +42,13 @@ exports.getDisplay = function (p, animals) {
 		},
 		color: p.config.embed_color,
 		fields: [],
+		footer: {
+			text: `Page ${page + 1} of ${totalPages}`,
+		},
 	};
 
-	let letterCount = embed.author.name.length;
-
-	for (let i in animals) {
-		let animal = animals[i];
-
+	for (let i in pageAnimals) {
+		let animal = pageAnimals[i];
 		let digits = 1;
 		let tempDigit = Math.log10(animal.stats.hp[1] + animal.stats.hp[3]) + 1;
 		if (tempDigit > digits) digits = tempDigit;
@@ -72,6 +71,7 @@ exports.getDisplay = function (p, animals) {
 		let pr = WeaponInterface.resToPrettyPercent(animal.stats.pr);
 		let mr = WeaponInterface.resToPrettyPercent(animal.stats.mr);
 		let stats = `<:hp:531620120410456064> \`${hp}\` <:wp:531620120976687114> \`${wp}\`\n<:att:531616155450998794> \`${att}\` <:mag:531616156231139338> \`${mag}\`\n<:pr:531616156222488606> \`${pr}\` <:mr:531616156226945024> \`${mr}\``;
+
 		let weapon = animal.weapon;
 		let weaponText = '';
 		if (weapon) {
@@ -92,13 +92,10 @@ exports.getDisplay = function (p, animals) {
 			)}/${p.global.toFancyNum(animal.stats.xp[1])}]\`\n${stats}\n${weaponText}`,
 			inline: true,
 		};
-
-		/* Discord embed char limit */
-		letterCount += field.name.length + field.value.length;
-		if (letterCount > 6000) return { embed };
-
 		embed.fields.push(field);
 	}
 
-	return { embed };
+	return embed;
 };
+
+exports.PAGE_SIZE = PAGE_SIZE;


### PR DESCRIPTION
Originally from a bug report in OwO Bot Support from the user Wraith, I figured to follow-up and suggest some possible changes at your discretion.

Problem:
`owo pets` silently cuts off pets once the embed hits Discord's 6000 character limit, and the SQL query was hard capped at 25 results. Users with larger collections have pets that never appear with no indication anything is missing.

The proposed changes would add pages to the command and allow better visibility for user's who have a higher pet amount that's been leveled in any way.

Changes:
- Increased SQL `LIMIT` from 25 to 100
- Removed the hard `letterCount > 6000` cutoff
- Refactored `getDisplay` to render 9 pets per page using the existing `PagedMessage` utility
- Added an empty pets check with a helpful error message

Notes:
No new files or dependencies, these fixes use `PagedMessage` which is already in the project's files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pet command now shows results across paged views with navigation and a "Page X of Y" footer.

* **Bug Fixes**
  * Validates pet list before displaying; returns an error if no pets found.
  * Removed the previous fixed cap on retrieved pets.
  * Removed prior character-limit truncation so full pet entries display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->